### PR TITLE
removed SF.net link from main Downloads link

### DIFF
--- a/navigation.div
+++ b/navigation.div
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div id="navidownloads">
-      <h1><a href="https://sourceforge.net/projects/openmsx/files/latest/download">Download</a></h1>
+      <h1><a href="https://github.com/openMSX/openMSX/releases/latest">Download</a></h1>
       <div class="linkblock">
         <h2>openMSX</h2>
         <ul>


### PR DESCRIPTION
22:06:41      <praduca> Hi to all
22:07:32      <praduca> I just noticed a possible wrong link on openmsx.org
22:08:44      <praduca> on the download menu, all links point to github, but the section title (the big DOWNLOAD) point to sourceforge 
22:08:55      <praduca> not a big deal, but hey :)

This commit changes that link to the latest release on Github.